### PR TITLE
Replace portal dataset with iDigBio dataset for Open Refine lesson

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,10 @@ http://onlinelibrary.wiley.com/doi/10.1111/afe.12051/full
 
 Master_suction_trap_data_list_uncleaned.csv is a pre-cleaning version of a publically available dataset by David Voegtlin, Doris Lagos, Douglas Landis and Christie Bahlai, available at http://lter.kbs.msu.edu/datatables/122
 
+<!-- Open Refine, R, and SQL data are from iDigBio for the NHC Data Carpentry data lessons. Datasets are on [figshare](https://figshare.com/collections/Dataset_Collection_for_Data_Carpentry_for_Natural_History_Collections_Lessons/3912553) and can be cited as 
+> Collins, Matthew; Paul, Deborah (2017): Dataset Collection for Data Carpentry for Natural History Collections Lessons. figshare.
+https://doi.org/10.6084/m9.figshare.c.3912553.v1 -->
+
 ## Lessons
 
 ### shell
@@ -29,12 +33,17 @@ Brown and Doug Latornell.
 Original materials adapted from Software Carpentry SQL lessons for ecologists by
 Ethan White, which were adapted from Greg Wilson's original SQL lessons.
 
+<!-- Original materials adapted from Data Carpentry SQL lessons for ecologists by Matthew Collins and Deborah Paul, which were adapted from Software Carpentry SQL lessons for ecologists by Ethan White, which were adapted from Greg Wilson's original SQL lessons. -->
+
 ### R materials
 Original materials adapted from SWC Python lessons by Sarah Supp.
 John Blischak led the continued development of materials with contributions
-from Gavin Simpson, Tracy Teal, Greg Wilson, Diego Barneche, Stephen Turner and Karthik Ram. 
+from Gavin Simpson, Tracy Teal, Greg Wilson, Diego Barneche, Stephen Turner and Karthik Ram.
+
+<!-- Original materials adapted from Data Carpentry R lessons for ecologists by Matthew Collins for the Data Carpentry NHC R Lessons. -->
 
 ### Spreadsheet Best Practices
 Original materials adapted from [Practical Data Management for Bug Counters](http://practicaldatamanagement.wordpress.com/) by Christie Bahlai <br>
 Christie Bahlai and Aleksandra Pawlik led the continued development of materials with contributions
 from Jennifer Bryan, Alexander Duryee, Jeffrey Hollister,  Daisie Huang, Owen Jones, and Ben Marwick
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
-## Data Carpentry OpenRefine Ecology lesson 2017.04.0
+## Data Carpentry OpenRefine Natural History Collections (NHC) lesson 2017.10.0
 
-Initial release of the Data Carpentry OpenRefine Ecology lesson
+Initial release of the Data Carpentry OpenRefine NHC lesson

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 OpenRefine lesson for Natural History collection data
 
 ### Data set notes.
-* This data set is derived from [iDigBio](http://portal.idigbio.org/)  natural science collections specimen data. [This data file](https://figshare.com/s/6fe692e2883347b4c15f) was  modified specifically for use with OpenRefine.
+* This data set is derived from [iDigBio](http://portal.idigbio.org/) natural science collections specimen data. [This data file](https://figshare.com/s/6fe692e2883347b4c15f) was  modified specifically for use with OpenRefine.
     * Some taxon names have errors introduced.
 <!--* One of the Globally Unique Identifiers (in the form of UUIDs) is changed to introduce looking for duplicates in this field.-->
 * These modifications were made in order to illustrate some features of Open Refine.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 OpenRefine lesson for Natural History collection data
 
 ### Data set notes.
-* This data set is derived from [The Portal Project Long-term desert ecology](http://portal.weecology.org/) project data. [This data file](http://www.esapubs.org/archive/ecol/E090/118/Portal_rodents_19772002.csv) was downloaded and then modified specifically for use with OpenRefine.
-    * Taxon names were put back into the file.
-    * Globally Unique Identifiers (in the form of UUIDs) were added.
+* This data set is derived from [iDigBio](http://portal.idigbio.org/)  natural science collections specimen data. [This data file](https://figshare.com/s/6fe692e2883347b4c15f) was  modified specifically for use with OpenRefine.
+    * Some taxon names have errors introduced.
+<!--* One of the Globally Unique Identifiers (in the form of UUIDs) is changed to introduce looking for duplicates in this field.-->
 * These modifications were made in order to illustrate some features of Open Refine.
     - Errors were added to the taxon names (`scientificName` field), to demonstrate OpenRefine's ability to find likely mis-entered data.
     - These errors can be found using clustering algorithms on the `scientificName` column, showing the power of the algorithms to find discrepancies quickly and making it simple to fix all issues found.

--- a/_episodes/01-working-with-openrefine.md
+++ b/_episodes/01-working-with-openrefine.md
@@ -28,7 +28,7 @@ Launch OpenRefine (see [Getting Started with OpenRefine](http://www.datacarpentr
 
 OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, Google Spreadsheets. See the [OpenRefine Importers page](https://github.com/OpenRefine/OpenRefine/wiki/Importers) for more information.
 
-In this first step, we'll browse our computer to the sample data file for this lesson. In this case, we modified the `idigbio_rodents` CSV file. Some data in `weight_g`, `length_mm`, are contrived and some spaces have been added to some text fields and these anomalies are in no way related to the original dataset.
+In this first step, we'll browse our computer to the sample data file for this lesson. In this case, we modified the `idigbio_rodents` CSV file. Some data in `weight`, `length`, are contrived and some spaces have been added to some text fields and these anomalies are in no way related to the original dataset.
 
 If you haven't already, download the data from:  
 [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f)
@@ -36,7 +36,7 @@ If you haven't already, download the data from:
 Once OpenRefine is launched in your browser, the left margin has options to `Create Project`, `Open Project`, or `Import Project`. Here we will create a new project:
 
 1. click `Create Project` and select `Get data from` `This Computer`.  
-2. Click `Choose Files` and select the file `idigbio_rodents_openrefine.csv`. Click `Open` or double-click on the filename.
+2. Click `Choose Files` and select the file `idigbio_rodents.csv`. Click `Open` or double-click on the filename.
 3. Click `Next>>` under the browse button to upload the data into OpenRefine.  
 4. OpenRefine gives you a preview - a chance to show you it understood the file. If, for example, your file was really tab-delimited, the preview might look strange, you would choose the correct separator in the box shown and click `Update Preview` (bottom left).
 5. For Character encoding, select `UTF-8`. In this case, it will insure that your text, no matter what language, is translated properly so that you don't see garbled output like `&Aring;` for Å, for example.

--- a/_episodes/01-working-with-openrefine.md
+++ b/_episodes/01-working-with-openrefine.md
@@ -28,20 +28,55 @@ Launch OpenRefine (see [Getting Started with OpenRefine](http://www.datacarpentr
 
 OpenRefine can import a variety of file types, including tab separated (`tsv`), comma separated (`csv`), Excel (`xls`, `xlsx`), JSON, XML, RDF as XML, Google Spreadsheets. See the [OpenRefine Importers page](https://github.com/OpenRefine/OpenRefine/wiki/Importers) for more information.
 
-In this first step, we'll browse our computer to the sample data file for this lesson. In this case, we modified the `Portal_rodents` CSV file, adding several columns: `scientificName`, `locality`, `county`, `state`, `country` and generating several more columns in the lesson itself (`JSON`, `decimalLatitude`, `decimalLongitude`). Data in `locality`, `county`, `country`, `JSON`, `decimalLatitude` and `decimalLongitude` are contrived and are in no way related to the original dataset. 
+In this first step, we'll browse our computer to the sample data file for this lesson. In this case, we modified the `idigbio_rodents` CSV file. Some data in `weight_g`, `length_mm`, are contrived and some spaces have been added to some text fields and these anomalies are in no way related to the original dataset.
 
 If you haven't already, download the data from:  
-[https://ndownloader.figshare.com/files/7823341](https://ndownloader.figshare.com/files/7823341)
+[https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f)
 
 Once OpenRefine is launched in your browser, the left margin has options to `Create Project`, `Open Project`, or `Import Project`. Here we will create a new project:
 
 1. click `Create Project` and select `Get data from` `This Computer`.  
-2. Click `Choose Files` and select the file `Portal_rodents_19772002_scinameUUIDs.csv`. Click `Open` or double-click on the filename.
+2. Click `Choose Files` and select the file `idigbio_rodents_openrefine.csv`. Click `Open` or double-click on the filename.
 3. Click `Next>>` under the browse button to upload the data into OpenRefine.  
-4. OpenRefine gives you a preview - a chance to show you it understood the file. If, for example, your file was really tab-delimited, the preview might look strange, you would choose the correct separator in the box shown and click `Update Preview` (bottom left). If this is the wrong file, click `<<Start Over` (upper left).  
-5. If all looks well, click `Create Project>>` (upper right). 
+4. OpenRefine gives you a preview - a chance to show you it understood the file. If, for example, your file was really tab-delimited, the preview might look strange, you would choose the correct separator in the box shown and click `Update Preview` (bottom left).
+5. For Character encoding, select `UTF-8`. In this case, it will insure that your text, no matter what language, is translated properly so that you don't see garbled output like `&Aring;` for Å, for example.
+	1. Learn more about [encoding](https://www.w3.org/International/questions/qa-what-is-encoding).
+5. If this is the wrong file, click `<<Start Over` (upper left).  
+6. If all looks well, click `Create Project>>` (upper right). 
 
 Note that at step 1, you could upload data in a standard form from a web address by selecting `Get data from` `Web Addresses (URLs)`. However, this won't work for all URLs.
+
+## Order Columns
+
+*Easily reorder columns to simplify work*
+
+OpenRefine makes it very simple to organize your columns, in comparison to a spreadsheet program.
+
+Use the scroll bar at the bottom of your screen to have a look across all the fields in this dataset. Let's move the `genus`, `specificEpithet`, and `scientificName` columns to just after `catalogNumber`. Also, move the `decimalLongitude` column to be before `decimalLatitude`.
+
+1. Just to the left of the `All` column header (the very first column), note the drop-down arrow.
+2. Click the *down arrow* and choose `Edit columns` > `Re-order``\remove columns`.
+3. In the resulting pop-up, scroll down to `genus` and click and hold to drag it up just after `catalogNumber`.
+4. Then do the same for `specificEpithet`, dragging it up to just after `genus`, and finish by moving `scientificName` just after `specificEpithet` and `decimalLongitude` column to before `decimalLatitude`.
+5. Click `OK` to complete moving the columns. 
+6. Note that if you wanted to remove columns, you only need to drag them to the right box in the pop-up.
+
+
+<!--## Unique Values
+
+*Discover easily if all values in a column are unique, or not.*
+
+In this dataset, the `uuid` column provides a *globally unique identifier* for each row in the dataset. Let's check to make sure there are no duplicates.
+
+1. Click on the *down arrow* in the `uuid` column and choose `Facet` > `Customized facets` > `Duplicates facet`.
+2. Note in the left panel, you get a box with two rows labeled `true` and `false` because we're asking, for each value, is it distinct (unique) or not.
+3. Click on `true`. What happens?
+
+> ## Solution
+
+> You see two rows and discover that the `uuids` for both rows are the same. (This error has been added to show how to use this feature of OpenRefine). If you scroll to the far right, you will see the correct `uuid` in the `notes` field. You can fix this now, if you note that you can hover over any given box and click `edit`. This will allow you to `copy-and-paste` the correct value into the `uuid` column. (If you skip this step it will not affect the rest of this lesson). 
+> {: .solution}
+> -->
 
 ## Faceting
 
@@ -68,28 +103,28 @@ along with a number representing how many times that value occurs in the column.
 
 > ## Solution
 > 
-> There will be several near-identical entries in `scientificName`. For example, there is one entry for `Ammospermophilis harrisi` and
-> one entry for `Ammospermophilus harrisii`. These are both misspellings of `Ammospermophilus harrisi`. We will see how to correct these 
+> There will be several near-identical entries in `scientificName`. For example, there is one entry for `Dipodomys agilia` and
+> one entry for `Dipodomis agilis`. These are both misspellings of `Dipodomys agilis`. We will see how to correct these 
 > misspelled and mistyped entries in a later exercise.  
 {: .solution}
 
 > ## Exercise
 >
-> 1. Using faceting, find out how many years are represented in the census.  
+> 1. Using faceting, find out how many years are represented in this dataset.  
 >
 > 2. Is the column formatted as Number, Date, or Text? How does changing the format change the faceting display?
 >
-> 3. Which years have the most and least observations?
+> 3. Which years have the most and least vouchered specimens and how many?
 > 
 > > ## Solution
 > > 
-> > 1. For the column `yr` do `Facet` > `Text facet`. A box will appear in the left panel showing that there are 26 unique entries in
+> > 1. For the column `year` do `Facet` > `Text facet`. A box will appear in the left panel showing that there are 70 unique entries in
 > > this column.  
-> > 2. By default, the column `yr` is formatted as Text. You can change the format by doing `Edit cells` > `Common transforms` > 
-> > `To number`. Doing `Facet` > `Numeric facet` creates a box in the left panel that shows a histogram of the number of 
-> > entries per year. Notice that the data is shown as a number, not a date. If you instead transform the column to a date, the 
-> > program will assume all entries are on January 1st of the year.   
-> > 3. After creating a facet, click `Sort by count` in the facet box. The year with the most observations is 1997. The least is 1977. 
+> > 2. Try `Edit cells` > `Common transforms` > `To text`, and you will note the `year` values are black and no longer green and the text is left-justified. Now the column `year` is formatted as Text. 
+> > You can change the format again by doing `Edit cells` > `Common transforms` > `To number` and see the values are green again and right-justified.
+> > Doing `Facet` > `Numeric facet` creates a box in the left panel that shows a histogram of the number of entries per year. Notice that the data is shown as a number, not a date. If you instead transform the column to a date, the 
+> > program will assume all entries are on January 1st of the year (yikes!).
+> > 3. After creating a facet, click `Sort by count` in the facet box. The year with the most specimens collected (vouchered) is 2007 with 711. The least is 1973 with one. 
 > > 
 > {: .solution}
 {: .challenge}
@@ -99,15 +134,15 @@ along with a number representing how many times that value occurs in the column.
 In OpenRefine, clustering means "finding groups of different values that might be alternative representations of the same thing". For example, the two strings `New York` and `new york` are very likely to refer to the same concept and just have capitalization differences. Likewise, `Gödel` and `Godel` probably refer to the same person. Clustering is a very powerful tool for cleaning datasets which contain misspelled or mistyped entries. OpenRefine has several clustering algorithms built in. Experiment with them, and learn more about these algorithms and how they work. 
 
 1. In the `scientificName` Text Facet we created in the step above, click the `Cluster` button.
-2. In the resulting pop-up window, you can change the `Method` and the `Keying Function`. Try different combinations to 
+2. In the resulting pop-up window, you can change the `Method` and the `Distance Function`. Try different combinations to 
  see what different mergers of values are suggested.
-3. Select the `key collision` method and `metaphone3` keying function. It should identify three clusters. 
-4. Click the `Merge?` box beside each, then click `Merge Selected and Recluster` to apply the corrections to the dataset.
-4. Try selecting different `Methods` and `Keying Functions` again, to see what new merges are suggested. You may find there are 
+3. Select the `nearest neighbor` method and `levenshtein` distance function. It should identify nine clusters. 
+4. Click the `Merge?` box beside the first five, then click `Merge Selected and Recluster` to apply the corrections to the dataset.
+4. Try selecting different `Methods` and `Distance Functions` again, to see what new merges are suggested. You may find there are 
  still improvements that can be made, but don't `Merge` again; just `Close` when you're done.  We'll now 
  see other operations that will help us detect and correct the remaining problems, and that have other, more general uses.
 
-Important: If you `Merge` using a different method or keying function, or more times than described in the instructions above, 
+Important: If you `Merge` using a different method or distance function, or more times than described in the instructions above, 
 your solutions for later exercises will not be the same as shown in those exercise solutions.
 
 [More on clustering](https://github.com/OpenRefine/OpenRefine/wiki/Clustering-In-Depth)
@@ -118,32 +153,30 @@ your solutions for later exercises will not be the same as shown in those exerci
 If data in a column needs to be split into multiple columns, and the parts are separated by a common separator (say a comma, or a space), you can use that separator to divide up the pieces into their own columns.
 
 
-1. Let us suppose we want to split the `scientificName` column into separate colums for genus and for species. 
+1. Let us suppose we want to split up the terms in the `scientificName` column into separate columns.
 2. Click the down arrow at the top of the `scientificName` column. Choose `Edit Column` > `Split into several columns...`
 3. In the pop-up, in the `Separator` box, replace the comma with a space.
 4. Uncheck the box that says `Remove this column`.
 5. Click `OK`. You'll get some new columns called `scientificName 1`, `scientificName 2`, and so on.
-6. Notice that in some cases `scientificName 1` and `scientificName 2` are empty. Why is this? What do you think we 
-can do to fix this?
+6. Notice that in some cases `scientificName 1` and `scientificName 2` are empty, as are `scientificName4` and `scientificName5`. (HINT: Use `Facet` > `Text facet` to help find the problems). Why is this? What do you think we can do to fix this?
 
 > ## Solution
 > 
-> The entries that have data in `scientificName 3` and `scientificName 4` but not the first two `scientificName` columns 
-> had an extra space at the beginning of the entry. Leading white spaces are very difficult to notice when cleaning data
+> For example, the entry that has data in `scientificName 2` and `scientificName 3` but not the `scientificName1` column had an extra space at the beginning of the entry. Leading white spaces are very difficult to notice when cleaning data
 > manually. This is another advantage of using OpenRefine to clean your data. We'll look at how to 
-> fix leading and trailing white spaces in a later exercise.
+> fix leading and trailing white spaces in a later exercise. HINT: Why do you think there are now columns `scientificName4` and `scientificName5`?
 {: .solution}
 
 > ## Exercise
 >
-> Try to change the name of the second new column to "species". How can you correct the problem you encounter?
+> Try to change the name of the second new column to "specificEpithet". How can you correct the problem you encounter?
 > 
 > > ## Solution
 > > 
-> > On the `scientificName 2` column, click the down arrow and then `Edit column` > `Rename this column`. Type "species" into the box
-> > that appears. A pop-up will appear that says `Another column already named species`. This is because there is another column
-> > where we've recorded the species abbreviation. You can choose another name like `speciesName` for this column or change the other 
-> > `species` column you can change the name to `speciesAbbreviation`.
+> > 1. On the `scientificName 2` column, click the down arrow and then `Edit column` > `Rename this column`. 
+> 2. Type `specificEpithet` into the box that appears. A pop-up will appear that says `Another column already named specificEpithet`. This is because there is another column where we've recorded the `specificEpithet` already.
+> 3. You can choose another name like `specificEpithet_test` for this column or change the other 
+> > `specificEpithet` column to another name like `speciesEpithet_original`.
 > {: .solution}
 {: .challenge}
 
@@ -166,12 +199,17 @@ Words with spaces at the beginning or end are particularly hard for we humans to
 
 1. In the header for the column `scientificName`, choose `Edit cells` > `Common transforms` > `Trim leading and trailing whitespace`.
 2. Notice that the `Split` step has now disappeared from the `Undo / Redo` pane on the left and is replaced with a `Text transform on 3 cells`
-3. Perform the same `Split` operation on `scientificName` that you undid earlier. This time you should only get two new columns. Why?
+3. Perform the same `Split` operation on `scientificName` that you undid earlier. Now you should only get three new columns. Why?
+4. Challenge. `Facet` > `text facet` on `scientificName2` column. Scroll down the `facet` results to discover the last entry. Why is there a blank cell for `scientificName2` in the second record row? Can you figure out how to fix this?
 
 > ## Solution
 > 
-> Removing the leading white spaces means that each entry in this column has exactly one space (between the genus and species names). 
-> Therefore, when you split with space as the separator, you will get only two columns.
+> For part 3 above, removing the leading white spaces means that each entry in this column has exactly one space (between the `genus`, species `specific epithet`, and the `infraspecificEpithet` names). Therefore, when you split with space as the separator, you will get only three columns.
+> 
+> For the Challenge (part 4), you will have discovered 2 consecutive whitespaces in between the `genus` and `specificEpithet` in the original `scientificName` column.  To fix this you will be glad to note that in addition to leading and trailing whitespaces, Open Refine gives you a way to find and fix these too. 
+> > 1. First, use `Undo/Re-do` to go back one step to remove the `Split 15000 cell(s) in column scientificName into several columns by separator`.
+> > 2. On the `scientificName` column drop-down, select `Edit cells` > `Common transforms` >  select `Collapse consecutive whitespace`.
+> > 3. Now you can repeat the `Split` operation on `scientificName` and you will get 3 new columns but no unexpected blanks. You can test this out by `text facet` of each resulting column and reviewing the `facet` values in the left panel.
 {: .solution}
 
 Important: `Undo` the splitting step before moving on to the next lesson. If you skip this step, your solutions 

--- a/_episodes/02-filter-exclude-sort.md
+++ b/_episodes/02-filter-exclude-sort.md
@@ -20,20 +20,18 @@ keypoints:
 There are many entries in our data table. We can filter it to work on a subset of the data in the list for the next set of operations. Please ensure you perform this step to save time during the class.
 
 1. Click the down arrow next to `scientificName` > `Text filter`. A `scientificName` facet will appear on the left margin.
-2. Type in `bai` and press return. There are 48 matching rows of the original 35549 rows (and these rows are selected for the subsequent steps).
-3. At the top, change the view to `Show` 50 `rows`. This way you will see all the matching rows.
+2. Type in `tra` you will automatically get the filtered rows matching this string `tra`. There are 22 matching rows of the original 15000 rows (and these rows are selected for the subsequent steps).
+3. At the top, change the view to `Show` 25 `rows`. This way you will see all the matching rows.
 
 > ## Exercise
 >
-> 1. What scientific names (genus and species) are selected by this procedure?  
+> 1. What scientific names are selected by this procedure?  
 > 2. How would you restrict this to one of the species selected?  
 > 
 > > ## Solution
 > > 1. Do `Facet` > `Text facet` on the `scientificName` column after filtering. This will show that
-> > two names match your filter criteria. They are `Baiomys taylori` and `Chaetodipus baileyi`.   
-> > 2. To restrict to only one of these two species, you could make the search case sensitive or 
-> > you could split the `scientificName` column into species and genus before filtering or
-> > you could include more letters in your filter.
+> > three names match your filter criteria. They are `Dipodomys microps centralis` and `Dipodomys nitratoides brevinasus` and `Thomomys talpoides rostralis`.   
+> > 2. To restrict to only one of these three species, you could split the `scientificName` column into three separate columns before filtering or you could include more letters in your filter, or ...
 > > 
 > {: .solution}
 {: .challenge}
@@ -53,17 +51,16 @@ is currently selected, while filtering allows you to select a subset of your dat
 >
 > > ## Solution
 > > 
-> > 1. In the facet (left margin), click on one of the names, such as `Baiomys taylori`. Notice that when you click on the name, or hover
-> > over it, there are entries to the right for `edit` and `include`. 
-> > 2. Click `include`. This will explicitly include this species, and exclude others that are not expicitly included. Notice that the
+> > 1. In the facet (left margin), click on one of the names, such as `Thomomys talpoides rostralis`. Notice that when you hover over it, there are entries to the right for `edit` and `include`. 
+> > 2. Click `include`. This will explicitly include records for this taxon, and exclude others that are not explicitly included. Notice that the
 > option now changes to `exclude`.
-> > 3. Click `include` and `exclude` on the other species (`Chaetodipus baileyi`) and notice how the two entries appear and disappear
-> >  from the table.
+> > 3. Click `include` and then `exclude` on one of the other species (`Dipodomys microps centralis`) and notice how the records for these 19 records appear and disappear from the table.
+> > 4. Note that you can `click` on a single name, in the `scientificName facet`, to `include` it. But this only works for one name.
 > > 
 > {: .solution}
 {: .challenge}
 
-Important: Select both species for your filtered dataset before continuing with the rest of the exercises.
+Important: Select (aka `include`) all three taxa for your filtered dataset before continuing with the rest of the exercises.
 
 ## Sort
 
@@ -86,10 +83,11 @@ If you try to re-sort a column that you have already used, the drop-down menu ch
 
 > ## Exercise
 > 
-> Sort the data by `plot`. What year(s) were observations recorded for plot 1 in this filtered dataset. 
+> Sort the data by `county`. What year(s) were specimens collected in Teller County in this filtered dataset?
 > 
 > > ## Solution
-> > In the `plot` column, select `Sort...` > `numbers` and select `smallest first`. The years represented are 1990 and 1995.
+> > 1. This dataset is small enough that a simple `Sort` by `county` gives you a `year` column you can read to discover that it's 1968.
+> > 2. You could sort by `year`. In the `year` column, select `Sort...` > `numbers` and select `smallest first`. The earliest year represented is 1968 and the `county` is Teller for both of these records.
 > > 
 > {: .solution}
 {: .challenge}
@@ -107,17 +105,17 @@ You can sort by multiple columns by performing sort on additional columns. The s
 > 
 > > ## Solution
 > > 
-> > 1. For the `mo` column, click on `Sort...` and then `numbers`. This will group all entries made in, for example, January,
+> > 1. For the `month` column, click on `Sort...` and then `numbers`. This will group all entries made in, for example, January,
 > > together, regardless of the year that entry was collected.  
-> > 2. For the `yr` column, click on `Sort` > `Sort...` > `numbers` and select `sort by this column alone`. This will undo the 
-> > sorting by month step. Once you've sorted by `yr` you can then apply another sorting step to sort by month within year. To do this
-> > for the `mo` column, click on `Sort` > `numbers` but do not select `sort by this column alone`. To ensure that all entries are shown 
+> > 2. For the `year` column, click on `Sort` > `Sort...` > `numbers` and select `sort by this column alone`. This will undo the 
+> > sorting by month step. Once you've sorted by `year` you can then apply another sorting step to sort by month within year. To do this
+> > for the `month` column, click on `Sort` > `numbers` but do not select `sort by this column alone`. To ensure that all entries are shown 
 > > chronologically, you will need to add a third sorting step by day within month. 
 > > 
 > {: .solution}  
 {: .challenge}
 
-If you go back to one of the already sorted colunms and select > `Sort` > `Remove sort`, that column is removed from your multiple sort. If it is the only column sorted, then data reverts to its original order.
+If you go back to one of the already sorted columns and select > `Sort` > `Remove sort`, that column is removed from your multiple sort. If it is the only column sorted, then data reverts to its original order.
 
 > ## Exercise
 >

--- a/_episodes/03-numbers.md
+++ b/_episodes/03-numbers.md
@@ -52,26 +52,26 @@ When done examining the numeric data, remove this facet by clicking the `x` in t
 
 ## Scatterplot facet
 
-Now that we have multiple columns representing numbers, we can see how they relate to one another and the text columns using the scatterplot facet. Select a numeric column, for example `weight_g`, and use the pulldown menu to > `Facet` > `Scatterplot facet`. A new window called `Scatterplot Matrix` will appear. There are squares for each pair of numeric columns organized in an upper right triangle. Each square has little dots for the cell values from each row.
+Now that we have multiple columns representing numbers, we can see how they relate to one another and the text columns using the scatterplot facet. Select a numeric column, for example `weight`, and use the pulldown menu to > `Facet` > `Scatterplot facet`. A new window called `Scatterplot Matrix` will appear. There are squares for each pair of numeric columns organized in an upper right triangle. Each square has little dots for the cell values from each row.
 
 > ## Exercise
 >
 > 1. Examine the scatterplots overall. Do the patterns make sense?
-> 2. Does the scatterplot for `weight_g` vs `month` look reasonable?
+> 2. Does the scatterplot for `weight` vs `month` look reasonable?
 {: .challenge}
 
 ## Examine pair of columns in detail
 
-We can examine one pair of columns by clicking on its square in the `Scatterplot Matrix`. A new facet with only that pair will appear in the left margin panel. Choose the scatterplot for `month (x)` vs `weight_g(y)` so we can look at it in more detail. 
+We can examine one pair of columns by clicking on its square in the `Scatterplot Matrix`. A new facet with only that pair will appear in the left margin panel. Choose the scatterplot for `month (x)` vs `weight (y)` so we can look at it in more detail. 
 
 > ## Exercise
 >
-> Click in the scatterplot facet in the left margin and drag to highlight a rectangle around one of the vertical lines representing `weight_g` for a given `month (x)`. This will subset the data to those entries.
+> Click in the scatterplot facet in the left margin and drag to highlight a rectangle around one of the vertical lines representing `weight` for a given `month (x)`. This will subset the data to those entries.
 {: .challenge}
 
 > ## Exercise
 > 
-> - Click on the `Scatterplot Matrix` square for `month (x)` and `weight_g(y)` to get that as a facet in the left margin.
+> - Click on the `Scatterplot Matrix` square for `month (x)` and `weight(y)` to get that as a facet in the left margin.
 > - Now Redo the `Text filter` on `scientificName` to show only entries including the letters `tra`.
 > Notice the change in the scatterplot. It might be easier to see if you click `export plot` to put it on a new browser tab.
 {: .challenge}

--- a/_episodes/03-numbers.md
+++ b/_episodes/03-numbers.md
@@ -10,7 +10,7 @@ objectives:
 - "Identify and modify non-numeric values in a column using facets."
 - "Use scatterplot facet to examine relationships among columns."
 keypoints:
-- "OpenRefine also provides ways to get overviews of numerical data."
+- "OpenRefine also provides ways to get visual overviews of numerical data."
 ---
 
 # Lesson
@@ -21,15 +21,15 @@ When a table is imported into OpenRefine, all columns are treated as having text
 
 Be sure to remove any `Text filter` facets you have enabled from the left panel so that we can examine our whole dataset. You can remove an existing facet by clicking the `x` in the upper left of that facet window.
 
-To transform cells in the `recordID` column to numbers, click the down arrow for that column, then `Edit cells` > `Common transforms…` > `To number`. You will notice the `recordID` values change from left-justified to right-justified, and black to green color.
+The `catalogNumber` field is already a number (it is likely green and right-justified). To transform cells in the `catalogNumber` column to text, click the down arrow for that column, then `Edit cells` > `Common transforms…` > `To text`. You will notice the `catalogNumber` values change from right-justified to left-justified, and from green color to black. Please change it back`To number`.
 
 > ## Exercise
 >
-> Transform three more columns, including `period`, from text to numbers. Can all columns be transformed to numbers?
+> Can any other columns in this dataset be transformed? Can all columns be transformed to numbers?
 > 
 > > ## Solution
 > > 
-> > Only observations that include only numerals (0-9) can be transformed to numbers. If you apply a number transformation to 
+> > Only fields with values that include only numerals (0-9) can be transformed to numbers. If you apply a number transformation to 
 > > a column that doesn't meet this criteria, and then click the `Undo / Redo` tab, you will see a step that starts with 
 > > `Text transform on 0 cells`. This means that the data in that column was not transformed.
 > > 
@@ -37,7 +37,7 @@ To transform cells in the `recordID` column to numbers, click the down arrow for
 {: .challenge}
 
 ### Numeric facet
-Sometimes there are non-number values or blanks in a column which may represent errors in data entry and we want to find them. 
+Sometimes there are *non-number values or blanks* in a column which may represent errors in data entry and we want to find them. 
 We can do that with a `Numeric facet`.
 
 > ## Exercise
@@ -52,26 +52,37 @@ When done examining the numeric data, remove this facet by clicking the `x` in t
 
 ## Scatterplot facet
 
-Now that we have multiple columns representing numbers, we can see how they relate to one another using the scatterplot facet. Select a numeric column, for example `recordID`, and use the pulldown menu to > `Facet` > `Scatterplot facet`. A new window called `Scatterplot Matrix` will appear. There are squares for each pair of numeric columns organized in an upper right triangle. Each square has little dots for the cell values from each row.
+Now that we have multiple columns representing numbers, we can see how they relate to one another and the text columns using the scatterplot facet. Select a numeric column, for example `weight_g`, and use the pulldown menu to > `Facet` > `Scatterplot facet`. A new window called `Scatterplot Matrix` will appear. There are squares for each pair of numeric columns organized in an upper right triangle. Each square has little dots for the cell values from each row.
 
 > ## Exercise
 >
 > 1. Examine the scatterplots overall. Do the patterns make sense?
-> 2. Why does the scatterplot for `recordID` vs `period` have the pattern it does?
+> 2. Does the scatterplot for `weight_g` vs `month` look reasonable?
 {: .challenge}
 
 ## Examine pair of columns in detail
 
-We can examine one pair of columns by clicking on its square in the `Scatterplot Matrix` A new facet with only that pair will appear in the left margin. 
+We can examine one pair of columns by clicking on its square in the `Scatterplot Matrix`. A new facet with only that pair will appear in the left margin panel. Choose the scatterplot for `month (x)` vs `weight_g(y)` so we can look at it in more detail. 
 
 > ## Exercise
 >
-> Click in the scatterplot facet in the left margin and drag to highlight a rectangle. This will subset the data to those entries.
+> Click in the scatterplot facet in the left margin and drag to highlight a rectangle around one of the vertical lines representing `weight_g` for a given `month (x)`. This will subset the data to those entries.
 {: .challenge}
 
 > ## Exercise
 > 
-> - Click on the `Scatterplot Matrix` square for `recordID` and `period` to get that as a facet in the left margin.
-> - Redo the `Text filter` on `scientificName` to show only entries including the letters `bai`.
+> - Click on the `Scatterplot Matrix` square for `month (x)` and `weight_g(y)` to get that as a facet in the left margin.
+> - Now Redo the `Text filter` on `scientificName` to show only entries including the letters `tra`.
 > Notice the change in the scatterplot. It might be easier to see if you click `export plot` to put it on a new browser tab.
+{: .challenge}
+
+> ## Exercise
+> 
+> - How could you see all the specimens collected in California, by a given collector (Patton) and displayed them on a map using the scatterplot facet? 
+> > 1. First on the `scientificName` column > `Facet` > `Text facet`. 
+> > 2. On the `recordedBy` column > `Facet` > `Text facet`.
+> > 3. On the `recordedBy` column > `Text filter` > enter *patton*. Now you have only data for specimens collected by Patton.
+> > 4. For `stateProvince` do > `Facet` > `Text facet` > and `include` only *california*. Now we have only rows where `recordedBy` contains *patton* and `stateProvince`=*california*.
+> > 5. For `decimalLongitude` > `Facet` > `Scatterplot facet` > click on the facet that is labeled `decimalLongitude(x)` vs. `decimalLatitude (y)` to get a facet graph in the left margin panel.
+> > 6. Notice the change in the scatterplot. It might be easier to see if you click `export plot` to put it on a new browser tab. How could you do this so that the graph only included California points? HINT: it involves dataset export from Open Refine.
 {: .challenge}

--- a/_episodes/04-scripts.md
+++ b/_episodes/04-scripts.md
@@ -28,7 +28,7 @@ This gives you a quick way to clean all of your related data.
 
 Let's practice running these steps on a new dataset. We'll test this on an uncleaned version of the dataset we've been working with. 
 
-1. Download an uncleaned version of the dataset: [https://ndownloader.figshare.com/files/7823341](https://ndownloader.figshare.com/files/7823341) or use the version of the raw dataset you saved to your computer.  
+1. Download an uncleaned version of the dataset: [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f) or use the version of the raw dataset you saved to your computer.  
 2. Start a new project in OpenRefine with this file and name it something different from your existing project.  
 3. Click the `Undo / Redo` tab > `Apply` and paste in the contents of `txt` file with the JSON code. 
 4. Click `Perform operations`. The dataset should now be the same as your other cleaned dataset.

--- a/_episodes/05-save-export.md
+++ b/_episodes/05-save-export.md
@@ -25,10 +25,13 @@ open it up again and be just where you stopped before.
 By default OpenRefine is saving your project. If you close OpenRefine and open it up again,
 you'll see a list of your projects. You can click on any one of them to open it up again.
 
+### Subset Export
+
+Any time you have faceted the dataset, for example, and you have just the rows of interest in your current subset, you can export that subset. Say you found 10 rows with errors, you can then click `Export` > `Comma separated` and you will get a csv file with just those 10 rows in it in your *downloads* folder. Be sure to re-name it meaningfully.
+
 ### Exporting
 
-You can also export a project. This is helpful, for instance, if you wanted to send your raw data and cleaning steps to a collaborator, 
-or share this information as a supplement to a publication. 
+You can also export a project. This is helpful, for instance, if you wanted to send your raw data and cleaning steps to a collaborator, or share this information as a supplement to a publication. 
 
 1. Click the `Export` button in the top right and select `Export project`.
 2. A `tar.gz` file will download to your default `Download` directory. The `tar.gz` extension tells you that this is a compressed file.
@@ -45,14 +48,14 @@ folder icon will now appear.
 {: .solution}
 
 You can import an existing project into OpenRefine by clicking `Open...` in the upper right > `Import Project` and selecting the `tar.gz` 
-project file. This project will include all of the raw data and cleaning steps that were part of the origina project.
+project file. This project will include all of the raw data and cleaning steps that were part of the original project.
 
 ## Exporting Cleaned Data 
 
 You can also export just your cleaned data, rather than the entire project.
 
 1. Click `Export` in the top right and select the file type you want to export the data in. `Tab-separated values` (`tsv`) or `Comma-separated values` (`csv`) would be good choices.
-2. That file will be exported to your default `Download` directory. That file can then be opened in a spreadsheet program or imported
-into programs like R or Python, which we'll be discussing later in our workshop.
+2. That file will be exported to your default `Download` directory. That file can then be opened in a spreadsheet program or imported into programs like R or Python, which we'll be discussing later in our workshop.
+3. Rename the file meaningfully and you may want to note all changes made in a separate text file with a matching name pattern. While Open Refine saves your steps, you may want them in plain text rather than as JSON.
 
 Remember from our lesson on Spreadsheets that using widely-supported, non-proprietary file formats like `tsv` or `csv` improves the ability of yourself and others to use your data. 

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ root: .
 ---
 
 A part of the data workflow is preparing the data for analysis. Some of this
-involves data cleaning, where errors in the data are identifed and corrected 
+involves data cleaning, where errors in the data are identified and corrected 
 or formatting
 made consistent. This step must be taken with the same care and attention
 to reproducibility as the analysis.

--- a/setup.md
+++ b/setup.md
@@ -5,18 +5,15 @@ permalink: /setup/
 ---
 
 > ## Data
-> **Download** this data file to your computer: [https://ndownloader.figshare.com/files/7823341](https://ndownloader.figshare.com/files/7823341)
+> **Download** this data file to your computer: [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f)
 >
 > #### About the data
-> The data for this lesson is a part of the Data Carpentry Ecology workshop. 
-> It is a teaching version of the Portal Database. The data in this lesson
-> is a subset of the teaching version that has been intentionally 'messed up'
-> for this lesson. 
+> The data for this lesson is a part of the Data Carpentry Natural History Collections workshop. It is a teaching version of a download of rodent data from the http://portal.idigbio.org/ for use in Open Refine for the Natural History Science Collections (NHC) Lessons for Data Carpentry.
+
+> Dataset description: common rodents in the continental United States from major institutions that publish extended information about their specimens. There are 10,767 rows in  the idigbio_rodents.csv file. The data in this lesson
+> are just a small subset of the available data at http://portal.idigbio.org. Data aggregated for this experience have been intentionally 'messed up' for this lesson. 
 > 
-> The data for this lesson and the workshop are in the 
-> [Portal Project Teaching Database](https://figshare.com/articles/Portal_Project_Teaching_Database/1314459) 
-> available on FigShare, with a CC-BY license 
-> available for reuse.
+> The data for this lesson are at [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f) on FigShare, with a CC-BY license available for reuse.
 {: .prereq}
 
 > ## Software

--- a/setup.md
+++ b/setup.md
@@ -8,12 +8,12 @@ permalink: /setup/
 > **Download** this data file to your computer: [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f)
 >
 > #### About the data
-> The data for this lesson is a part of the Data Carpentry Natural History Collections workshop. It is a teaching version of a download of rodent data from the http://portal.idigbio.org/ for use in Open Refine for the Natural History Science Collections (NHC) Lessons for Data Carpentry.
+> The data for this lesson is a part of the Data Carpentry Natural History Collections workshop. It is a teaching version of a download of rodent data from the http://portal.idigbio.org/ for use in Open Refine for the Natural History Science Collections (NHC) Lessons for Data Carpentry. See more information about the NHC datasets for Data Carpentry on [figshare](https://doi.org/10.6084/m9.figshare.c.3912553.v1).
 
 > Dataset description: common rodents in the continental United States from major institutions that publish extended information about their specimens. There are 10,767 rows in  the idigbio_rodents.csv file. The data in this lesson
 > are just a small subset of the available data at http://portal.idigbio.org. Data aggregated for this experience have been intentionally 'messed up' for this lesson. 
 > 
-> The data for this lesson are at [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f) on FigShare, with a CC-BY license available for reuse.
+> The data for this lesson are at [https://figshare.com/s/6fe692e2883347b4c15f](https://figshare.com/s/6fe692e2883347b4c15f) on Figshare, with a CC-BY license available for reuse.
 {: .prereq}
 
 > ## Software


### PR DESCRIPTION
This PR replaces the Portal teaching dataset in the Open Refine lesson with one built from aggregated iDigBio's specimen data. More information on the data is available on FigShare: https://figshare.com/collections/Dataset_Collection_for_Data_Carpentry_for_Natural_History_Collections_Lessons/3912553

There are few other changes to the lesson besides using different columns from the dataset to illustrate the same points of the lesson.

